### PR TITLE
Remove inaccurate clause

### DIFF
--- a/en/guides/publishing-open-source-code.md
+++ b/en/guides/publishing-open-source-code.md
@@ -149,7 +149,7 @@ Projects names should be bilingual but repositories names can be unilingual or u
 
 ## Add Mandatory Files
 
-Before publishing, source code must include the following file to be considered as open source:
+Before publishing, source code must include the following file:
 
 - a `LICENCE` (see [Select Open Source Software Licence](#select-open-source-software-licence)) file containing a copy of the licence under under which the source code is released;
 


### PR DESCRIPTION
Inclusion of a LICENSE file is a best practice, not a definitional requirement.  Code can be open source even without a LICENSE file.  The instructions work fine without that clause, so I propose just deleting it.